### PR TITLE
feat: 메인 레이아웃 및 그리드 카드 뷰 추가 (#4)

### DIFF
--- a/src/entities/teams/ui/TeamCard.tsx
+++ b/src/entities/teams/ui/TeamCard.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface Props {
+  item: string;
+}
+
+const TeamCard: React.FC<Props> = ({ item }) => {
+  return <div>{item}팀</div>;
+};
+
+export default TeamCard;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 
+import TeamPage from '@/pages/TeamPage';
+
 const HomePage: React.FC = () => {
-  return (
-    <div className='flex justify-center items-center h-screen bg-gray2'>
-      <h1 className='text-3xl font-bold'>Rolling Paper</h1>
-    </div>
-  );
+  return <TeamPage />;
 };
 
 export default HomePage;

--- a/src/pages/TeamPage.tsx
+++ b/src/pages/TeamPage.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import TeamCard from '@/entities/teams/ui/TeamCard';
+import MainLayout from '@/shared/layouts/MainLayout';
+import CardGrid from '@/widgets/CardGrid';
+
+const TeamPage: React.FC = () => {
+  return (
+    <MainLayout>
+      <h1 className='text-3xl font-bold'>Rolling Paper</h1>
+      <CardGrid items={Array.from({ length: 13 }, (_, index) => index + 1)} RenderItem={TeamCard} />
+    </MainLayout>
+  );
+};
+
+export default TeamPage;

--- a/src/shared/layouts/MainLayout.tsx
+++ b/src/shared/layouts/MainLayout.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const MainLayout: React.FC<Props> = ({ children }) => {
+  return (
+    <div className='flex flex-col min-h-screen min-w-[390px]'>
+      <main className=' w-full mx-auto'>{children}</main>
+    </div>
+  );
+};
+
+export default MainLayout;

--- a/src/widgets/CardGrid.tsx
+++ b/src/widgets/CardGrid.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+interface CardGridProps<T> {
+  items: T[];
+  RenderItem: React.ComponentType<{ item: T }>;
+}
+
+const CardGrid: React.FC<CardGridProps<any>> = ({ items, RenderItem }) => {
+  return (
+    <div className='w-full flex justify-center '>
+      <div
+        className={`
+          p-6
+          bg-gray-400
+          inline-grid
+          grid-cols-[repeat(1,_306px)]
+          md:grid-cols-[repeat(3,_212px)]
+          xl:grid-cols-[repeat(4,_311px)]
+          gap-x-6
+          gap-y-6
+          mx-auto
+          rounded-lg
+        `}
+      >
+        {items.map((item, index) => (
+          <div
+            key={index}
+            className={`
+              aspect-square
+              bg-gray-200
+              flex items-center justify-center
+              text-xl font-semibold
+              rounded-lg
+            `}
+          >
+            <RenderItem item={item} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CardGrid;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #4

## #️⃣ 작업 내용

> MainLayout 구현 및 화면 사이즈 별 GridCard 뷰 컴포넌트 구현

## #️⃣ 테스트 결과

> 디바이스 사이즈 별 UI 깨짐 여부 확인 완료
여백 사이즈 적용 완료

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

<img width="320" src="https://github.com/user-attachments/assets/9e2e19f6-fe4b-4659-9923-e013445af4c3" />
<img width="270" src="https://github.com/user-attachments/assets/5b5aafef-c884-474e-9d80-98a8c35220a8" />
<img width="190" src="https://github.com/user-attachments/assets/2a34cbcc-b571-4ca3-bc34-1defaade9670" />
