### PR TITLE
feat: 해더 컴포넌트 구현 (#7)

### DIFF
--- a/src/entities/teams/ui/TeamCard.tsx
+++ b/src/entities/teams/ui/TeamCard.tsx
@@ -5,7 +5,7 @@ interface Props {
 }
 
 const TeamCard: React.FC<Props> = ({ item }) => {
-  return <div>{item}팀</div>;
+  return <div className='aspect-square bg-gray-200 rounded-lg'>{item}팀</div>;
 };
 
 export default TeamCard;

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,16 @@
   --color-point-55: #fffee8;
 }
 
+.font-bmdohy {
+  font-family: 'BMDOHYEON', sans-serif;
+}
+.font-gowun {
+  font-family: 'GowunDodum-Regular', sans-serif;
+}
+.font-interop {
+  font-family: 'Interop', sans-serif;
+}
+
 @font-face {
   font-family: 'BMDOHYEON';
   src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_one@1.0/BMDOHYEON.woff')

--- a/src/index.css
+++ b/src/index.css
@@ -1,73 +1,46 @@
 @import 'tailwindcss';
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@theme {
+  --color-azure-11: #0f1729;
+  --color-azure-34: #485563;
+  --color-azure-36: #1b5a9b;
+  --color-azure-47: #647a8b;
+  --color-azure-61: #4f9be9;
+  --color-azure-82: #a1d6ff;
+  --color-azure-88: #c1e3ff;
 
-@layer base {
-  :root {
-    --color-azure-11: #0F1729;
-    --color-azure-34: #485563;
-    --color-azure-36: #1B5A9B;
-    --color-azure-47: #647A8B;
-    --color-azure-61: #4F9BE9;
-    --color-azure-82: #A1D6FF;
-    --color-azure-88: #C1E3FF;
+  --color-grey-46: #66728d;
+  --color-grey-91: #e2e8fd;
+  --color-grey-92: #d5eaff;
+  --color-grey-95: #e6f4ff;
+  --color-grey-96: #f3f4f6;
 
-    --color-grey-46: #66728D;
-    --color-grey-91: #E2E8FD;
-    --color-grey-92: #D5EAFF;
-    --color-grey-95: #E6F4FF;
-    --color-grey-96: #F3F4F6;
-
-    --color-point-22: #FFE8F0;
-    --color-point-33: #EBF0FF;
-    --color-point-44: #F0FFF8;
-    --color-point-55: #FFFEE8;
-  }
+  --color-point-22: #ffe8f0;
+  --color-point-33: #ebf0ff;
+  --color-point-44: #f0fff8;
+  --color-point-55: #fffee8;
 }
-
-@layer utilities {
-  .bg-azure-11 { background-color: var(--color-azure-11); }
-  .bg-azure-34 { background-color: var(--color-azure-34); }
-  .bg-azure-36 { background-color: var(--color-azure-36); }
-  .bg-azure-47 { background-color: var(--color-azure-47); }
-  .bg-azure-61 { background-color: var(--color-azure-61); }
-  .bg-azure-82 { background-color: var(--color-azure-82); }
-  .bg-azure-88 { background-color: var(--color-azure-88); }
-
-  .bg-grey-46 { background-color: var(--color-grey-46); }
-  .bg-grey-91 { background-color: var(--color-grey-91); }
-  .bg-grey-92 { background-color: var(--color-grey-92); }
-  .bg-grey-95 { background-color: var(--color-grey-95); }
-  .bg-grey-96 { background-color: var(--color-grey-96); }
-
-  .bg-point-22 { background-color: var(--color-point-22); }
-  .bg-point-33 { background-color: var(--color-point-33); }
-  .bg-point-44 { background-color: var(--color-point-44); }
-  .bg-point-55 { background-color: var(--color-point-55); }
-
-}
-
-
 
 @font-face {
   font-family: 'BMDOHYEON';
-  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_one@1.0/BMDOHYEON.woff') format('woff');
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_one@1.0/BMDOHYEON.woff')
+    format('woff');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'GowunDodum-Regular';
-  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/GowunDodum-Regular.woff') format('woff');
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/GowunDodum-Regular.woff')
+    format('woff');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'Interop';
-  src: url('https://raw.githubusercontent.com/payw-org/Interop/main/web/fonts/Interop-Regular.woff2')
+  src:
+    url('https://raw.githubusercontent.com/payw-org/Interop/main/web/fonts/Interop-Regular.woff2')
       format('woff2'),
     url('https://raw.githubusercontent.com/payw-org/Interop/main/web/fonts/Interop-Regular.woff')
       format('woff');
@@ -76,10 +49,14 @@
   font-display: block;
 }
 
-h1, h2, h3, .link, .link1{
+h1,
+h2,
+h3,
+.link,
+.link1 {
   font-family: 'BMDOHYEON';
 }
 
-body{
+body {
   background-color: #e6f4ff;
 }

--- a/src/pages/TeamPage.tsx
+++ b/src/pages/TeamPage.tsx
@@ -6,7 +6,10 @@ import CardGrid from '@/widgets/CardGrid';
 
 const TeamPage: React.FC = () => {
   return (
-    <MainLayout>
+    <MainLayout
+      title='롤링페이퍼'
+      description='프론트엔드 부트캠프 수료생들을 위한 롤링페이퍼입니다. 팀을 선택하여 메시지를 남겨보세요!'
+    >
       <CardGrid items={Array.from({ length: 13 }, (_, index) => index + 1)} RenderItem={TeamCard} />
     </MainLayout>
   );

--- a/src/pages/TeamPage.tsx
+++ b/src/pages/TeamPage.tsx
@@ -7,7 +7,6 @@ import CardGrid from '@/widgets/CardGrid';
 const TeamPage: React.FC = () => {
   return (
     <MainLayout>
-      <h1 className='text-3xl font-bold'>Rolling Paper</h1>
       <CardGrid items={Array.from({ length: 13 }, (_, index) => index + 1)} RenderItem={TeamCard} />
     </MainLayout>
   );

--- a/src/shared/Icons.tsx
+++ b/src/shared/Icons.tsx
@@ -21,8 +21,12 @@ import {
 
 //Design System에 표기되어있는 순서, 사이즈
 
-export const SparklesIcon = () => {
-  return <Sparkles size={32} />;
+interface IconProps {
+  className?: string;
+}
+
+export const SparklesIcon = ({ className }: IconProps) => {
+  return <Sparkles className={className} size={32} />;
 };
 
 export const CopyIcon = () => {

--- a/src/shared/layouts/MainLayout.tsx
+++ b/src/shared/layouts/MainLayout.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 
+import Header from '@/widgets/Header';
+
 interface Props {
   children: React.ReactNode;
 }
 
 const MainLayout: React.FC<Props> = ({ children }) => {
   return (
-    <div className='flex flex-col min-h-screen min-w-[390px]'>
-      <main className=' w-full mx-auto'>{children}</main>
+    <div className='flex flex-col min-h-screen min-w-[390px] py-8 px-4 lg:px-9'>
+      <Header />
+      <main className='w-full mx-auto text-center'>{children}</main>
     </div>
   );
 };

--- a/src/shared/layouts/MainLayout.tsx
+++ b/src/shared/layouts/MainLayout.tsx
@@ -3,13 +3,15 @@ import React from 'react';
 import Header from '@/widgets/Header';
 
 interface Props {
+  title: string;
+  description: string;
   children: React.ReactNode;
 }
 
-const MainLayout: React.FC<Props> = ({ children }) => {
+const MainLayout: React.FC<Props> = ({ title, description, children }) => {
   return (
     <div className='flex flex-col min-h-screen min-w-[390px] py-8 px-4 lg:px-9'>
-      <Header />
+      <Header title={title} description={description} />
       <main className='w-full mx-auto text-center'>{children}</main>
     </div>
   );

--- a/src/widgets/CardGrid.tsx
+++ b/src/widgets/CardGrid.tsx
@@ -7,36 +7,22 @@ interface CardGridProps<T> {
 
 const CardGrid: React.FC<CardGridProps<any>> = ({ items, RenderItem }) => {
   return (
-    <div className='w-full flex justify-center '>
-      <div
-        className={`
+    <div
+      className={`
           p-6
           bg-gray-400
           inline-grid
           grid-cols-[repeat(1,_306px)]
           md:grid-cols-[repeat(3,_212px)]
-          xl:grid-cols-[repeat(4,_311px)]
+          2xl:grid-cols-[repeat(4,_311px)]
           gap-x-6
           gap-y-6
-          mx-auto
           rounded-lg
         `}
-      >
-        {items.map((item, index) => (
-          <div
-            key={index}
-            className={`
-              aspect-square
-              bg-gray-200
-              flex items-center justify-center
-              text-xl font-semibold
-              rounded-lg
-            `}
-          >
-            <RenderItem item={item} />
-          </div>
-        ))}
-      </div>
+    >
+      {items.map((item, index) => (
+        <RenderItem key={index} item={item} />
+      ))}
     </div>
   );
 };

--- a/src/widgets/Header.tsx
+++ b/src/widgets/Header.tsx
@@ -1,16 +1,22 @@
 import React from 'react';
 
-// TODO: 공통 디자인 셋업 적용 필요
-const Header: React.FC = () => {
+import { SparklesIcon } from '@/shared/Icons';
+
+interface Props {
+  title: string;
+  description: string;
+}
+
+const Header: React.FC<Props> = ({ title, description }) => {
   return (
     <div className='flex flex-col items-center'>
-      <div>
-        {/* icon 추가 */}
-        <h1 className='text-[40px] mx-2'>롤링페이퍼</h1>
-        {/* icon 추가 */}
+      <div className='flex items-center justify-center'>
+        <SparklesIcon className='text-azure-61' />
+        <h1 className='text-[40px] mx-2 text-azure-36'>{title}</h1>
+        <SparklesIcon className='text-azure-82' />
       </div>
-      <p className='max-w-[685px] my-2 text-[18px] '>
-        프론트엔드 부트캠프 수료생들을 위한 롤링페이퍼입니다. 팀을 선택하여 메시지를 남겨보세요!
+      <p className='max-w-[685px] my-2 text-[18px] font-gowun text-center text-azure-34'>
+        {description}
       </p>
     </div>
   );

--- a/src/widgets/Header.tsx
+++ b/src/widgets/Header.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+// TODO: 공통 디자인 셋업 적용 필요
+const Header: React.FC = () => {
+  return (
+    <div className='flex flex-col items-center'>
+      <div>
+        {/* icon 추가 */}
+        <h1 className='text-[40px] mx-2'>롤링페이퍼</h1>
+        {/* icon 추가 */}
+      </div>
+      <p className='max-w-[685px] my-2 text-[18px] '>
+        프론트엔드 부트캠프 수료생들을 위한 롤링페이퍼입니다. 팀을 선택하여 메시지를 남겨보세요!
+      </p>
+    </div>
+  );
+};
+
+export default Header;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #7 

## #️⃣ 작업 내용

> widgets/Header 컴포넌트를 구현 했습니다. UI 구현 및 스타일 적용 완료 후 다른 페이지에서도 간단하게 재사용 할 수 있게 마무리 하였고, 추가로 custom theme, font 설정 오류를 수정하기 위해 v4.x 공식문서를 참고하여 세팅 방식을 변경하였습니다.

## #️⃣ 테스트 결과

> 스크린 별 레이아웃에 맞춰 텍스트 너비가 동적으로 잘 변경되는지 테스트 하였습니다. index.css 변경에 따른 문제가 없는지도 검토 완료했습니다.

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요

디자인 셋업 pull 받고 작업하던 중 이전 버전의 tailwindcss 세팅으로 인해 Problem이 생기는 점, custom color 변수가 지정되어 있음에도 border, text, bg 에 적용하려면 또 추가로 설정해야 하는 점 때문에 v4.x를 기준으로 한 공식문서를 참고하여 index.css 파일을 수정하였습니다.
🔗 [공식문서](https://tailwindcss.com/docs/theme#customizing-your-theme)
🔗 [unknown-at-rule](https://flaviocopes.com/fix-unknown-at-rule-tailwind/)
